### PR TITLE
Re-order opening of HTTP Ports

### DIFF
--- a/ProxyServerModuleUnit.pas
+++ b/ProxyServerModuleUnit.pas
@@ -203,18 +203,18 @@ begin
 
     try
       fServer.Bindings.Clear;
-      // Needed by NextPVR to find lineup.xml
-      with fServer.Bindings.Add do
-      begin
-        IP := lListenIP;
-        Port := 80;
-      end;
       with fServer.Bindings.Add do
       begin
         IP := lListenIP;
         Port := lHTTPPort;
       end;
       fServer.Active := True;
+      // Needed by NextPVR to find lineup.xml
+      with fServer.Bindings.Add do
+      begin
+        IP := lListenIP;
+        Port := 80;
+      end;
     except
       TLogger.Log(cLogDefault, 'Unable to bind HTTP server listening port');
     end;


### PR DESCRIPTION
Open the configured HTTP port first (instead of port 80) and indicate the server is active even if opening of port 80 is not successful.  This will allow cetonproxy to be run by a non-root user inside a Wine environment on Linux for use with Emby/Plex.  Port 80 is a privileged port on Linux, so not available to a non-root user without jumping through some hoops.  An alternative would be to include a configuration parameter (or GUI option) to inhibit attempting to open port 80 for configurations where it is not needed.