### PR TITLE
Add /lineup.m3u representation

### DIFF
--- a/ProxyWebModuleUnit.dfm
+++ b/ProxyWebModuleUnit.dfm
@@ -29,6 +29,11 @@ object ProxyWebModule: TProxyWebModule
       OnAction = ProxyWebModuleLineupXMLActionAction
     end
     item
+      Name = 'LineupM3UAction'
+      PathInfo = '/lineup.m3u'
+      OnAction = ProxyWebModuleLineupM3UActionAction
+    end
+    item
       Name = 'TunerAction'
       PathInfo = '/tuner[0-99]/v*'
       OnAction = ProxyWebModuleTunerActionAction

--- a/ProxyWebModuleUnit.pas
+++ b/ProxyWebModuleUnit.pas
@@ -50,6 +50,8 @@ type
       Response: TWebResponse; var Handled: Boolean);
     procedure ProxyWebModuleLineupXMLActionAction(Sender: TObject;
       Request: TWebRequest; Response: TWebResponse; var Handled: Boolean);
+    procedure ProxyWebModuleLineupM3UActionAction(Sender: TObject;
+      Request: TWebRequest; Response: TWebResponse; var Handled: Boolean);
     procedure ProxyWebModuleTunerActionAction(Sender: TObject;
       Request: TWebRequest; Response: TWebResponse; var Handled: Boolean);
     procedure WebModuleCreate(Sender: TObject);
@@ -370,6 +372,32 @@ begin
       end;
     finally
       TLogger.LogFmt(cLogDefault, 'Finished lineup.json request from %s', [Request.RemoteAddr]);
+    end;
+  except
+    HandleException;
+  end;
+end;
+
+procedure TProxyWebModule.ProxyWebModuleLineupM3UActionAction(Sender: TObject;
+  Request: TWebRequest; Response: TWebResponse; var Handled: Boolean);
+var
+  lLineup: TLineup;
+begin
+  Handled := True;
+  try
+    TLogger.LogFmt(cLogDefault, 'Received lineup.m3u request from %s', [Request.RemoteAddr]);
+    try
+      lLineup := TLineup.Create;
+      try
+        GetLineup(lLineup);
+
+        Response.ContentType := 'audio/x-mpegurl';
+        Response.Content := lLineup.ToM3U;
+      finally
+        lLineup.Free;
+      end;
+    finally
+      TLogger.LogFmt(cLogDefault, 'Finished lineup.m3u request from %s', [Request.RemoteAddr]);
     end;
   except
     HandleException;

--- a/hdhr/HDHR.pas
+++ b/hdhr/HDHR.pas
@@ -218,6 +218,7 @@ type
 
     function ToJSON: String;
     function ToXML: String;
+    function ToM3U: String;
   end;
 
   THDHRUtils = class abstract
@@ -332,6 +333,25 @@ begin
   end;
 
   Result := lXMLDoc.XML.Text;
+end;
+
+function TLineup.ToM3U: String;
+var
+  out: string;
+  lItem: TLineupItem;
+  i: Integer;
+begin
+  out := '#EXTM3U' + #13;
+
+  for i := 0 to fList.Count-1 do
+  begin
+    lItem := fList[i];
+
+    out := out + '#EXTINF:0 channel-number="' + lItem.GuideNumber + '",' + lItem.GuideName + #13;
+    out := out + lItem.URL + #13 + #13;
+  end;
+
+  Result := out;
 end;
 
 { TTag }


### PR DESCRIPTION
Hi, thanks for your work on this project!

I've added a new `/lineup.m3u` endpoint which exposes the channels in a simple M3U playlist. This can be imported into a wide variety of media playback software.

Note that I have never written pascal before and was not able to compile test this. However I followed the JSON/XML examples closely and am fairly confident it will work as expected.